### PR TITLE
Fixed hardcoded value and project dependency.

### DIFF
--- a/source/OctoFX.TradingWebsite/OctoFX.TradingWebsite.csproj
+++ b/source/OctoFX.TradingWebsite/OctoFX.TradingWebsite.csproj
@@ -327,6 +327,11 @@
       <Project>{9316AE68-1295-4A98-9C84-DCF136B9F10B}</Project>
       <Name>OctoFX.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\OctoFX.Tests\OctoFX.Tests.csproj">
+      <Project>{6e77b735-90f7-41be-b764-f5acc39843c9}</Project>
+      <Name>OctoFX.Tests</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -358,7 +363,7 @@
   </ProjectExtensions>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y /I  "$(SolutionDir)OctoFX.Tests\bin\Debug\*" "$(TargetDir)test"</PostBuildEvent>
+    <PostBuildEvent>xcopy /y /I  "$(SolutionDir)OctoFX.Tests\bin\$(Configuration)\*" "$(TargetDir)test"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\OctoPack.3.6.1\build\OctoPack.targets" Condition="Exists('..\packages\OctoPack.3.6.1\build\OctoPack.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
These fixes are intended to make the solution buildable on team build

xcopy had a debug value hardcoded this makes the build fail on release
since xcopy fails.
If the intention is to run only on debug this should be guarded with a
condition

Added a dependency on OctoFx.Tests for OctoFX.TradingWebsite project,
since there was no dependency specified, build can fail when msbuild is
used (msbuild doesn't guarantees ordering) if OctoFX.Tests have not been
built (xcopy fails).
